### PR TITLE
fix edge addition for nested symbols

### DIFF
--- a/src/numbat/api.py
+++ b/src/numbat/api.py
@@ -277,8 +277,8 @@ class SourcetrailDB():
 
         # Add all the edges between nodes
         if len(ids) > 1:
-            parent, children = ids[0], ids[1:]
-            for child in children:
+            for i in range(1, len(ids)):
+                parent, child = ids[i-1], ids[i]
                 elem = Element()
                 elem.id = ElementDAO.new(self.database, elem)
 


### PR DESCRIPTION
The current behavior of ``_record_symbol`` seems incorrect to add edges.

If we have the following hierarchy:  module1 -> module2 -> module3, in the current behavior the edge will always be added with the module1 as parent. As such, there will not be the link module2 -> module3.

This behavior seems incorrect, but maybe I missed something ?

Here is a fix, to make to add the edge with the immediate parent.

Works for me ™️. 